### PR TITLE
Add async manager adapter

### DIFF
--- a/internal/manager/async_adapter.go
+++ b/internal/manager/async_adapter.go
@@ -1,0 +1,86 @@
+package manager
+
+import (
+	"aur-cache-service/api/dto"
+	"context"
+	"log"
+)
+
+// AsyncManagerAdapter provides a simplified interface over Manager.
+// PutAll and EvictAll are executed asynchronously to reduce
+// blocking of the calling goroutine.
+type AsyncManagerAdapter interface {
+	Get(ctx context.Context, id *dto.CacheId) *dto.CacheEntryHit
+	Put(ctx context.Context, entry *dto.CacheEntry)
+	Evict(ctx context.Context, id *dto.CacheId)
+
+	GetAll(ctx context.Context, ids []*dto.CacheId) []*dto.CacheEntryHit
+	PutAll(ctx context.Context, entries []*dto.CacheEntry)
+	EvictAll(ctx context.Context, ids []*dto.CacheId)
+}
+
+type asyncManagerAdapter struct {
+	manager Manager
+}
+
+// NewAsyncAdapter creates a new AsyncManagerAdapter for the provided Manager.
+func NewAsyncAdapter(m Manager) AsyncManagerAdapter {
+	return &asyncManagerAdapter{manager: m}
+}
+
+func (f *asyncManagerAdapter) Get(ctx context.Context, id *dto.CacheId) *dto.CacheEntryHit {
+	if id == nil {
+		return nil
+	}
+	res := f.GetAll(ctx, []*dto.CacheId{id})
+	if len(res) == 0 {
+		return nil
+	}
+	return res[0]
+}
+
+func (f *asyncManagerAdapter) Put(ctx context.Context, entry *dto.CacheEntry) {
+	if entry == nil {
+		return
+	}
+	f.PutAll(ctx, []*dto.CacheEntry{entry})
+}
+
+func (f *asyncManagerAdapter) Evict(ctx context.Context, id *dto.CacheId) {
+	if id == nil {
+		return
+	}
+	f.EvictAll(ctx, []*dto.CacheId{id})
+}
+
+func (f *asyncManagerAdapter) GetAll(ctx context.Context, ids []*dto.CacheId) []*dto.CacheEntryHit {
+	return f.manager.GetAll(ctx, ids)
+}
+
+func (f *asyncManagerAdapter) PutAll(ctx context.Context, entries []*dto.CacheEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("panic in PutAll goroutine: %v", r)
+			}
+		}()
+		f.manager.PutAll(ctx, entries)
+	}()
+}
+
+func (f *asyncManagerAdapter) EvictAll(ctx context.Context, ids []*dto.CacheId) {
+	if len(ids) == 0 {
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("panic in EvictAll goroutine: %v", r)
+			}
+		}()
+		f.manager.EvictAll(ctx, ids)
+	}()
+}

--- a/internal/manager/async_adapter_test.go
+++ b/internal/manager/async_adapter_test.go
@@ -1,0 +1,110 @@
+package manager
+
+import (
+	"aur-cache-service/api/dto"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockManager struct {
+	mu             sync.Mutex
+	getAllCalled   int
+	putAllCalled   int
+	evictAllCalled int
+	wait           time.Duration
+	putWG          sync.WaitGroup
+	evictWG        sync.WaitGroup
+}
+
+func (m *mockManager) GetAll(ctx context.Context, ids []*dto.CacheId) []*dto.CacheEntryHit {
+	m.mu.Lock()
+	m.getAllCalled++
+	m.mu.Unlock()
+	hits := make([]*dto.CacheEntryHit, len(ids))
+	for i, id := range ids {
+		hits[i] = &dto.CacheEntryHit{CacheEntry: &dto.CacheEntry{CacheId: id}, Found: true}
+	}
+	return hits
+}
+
+func (m *mockManager) PutAll(ctx context.Context, entries []*dto.CacheEntry) {
+	defer m.putWG.Done()
+	time.Sleep(m.wait)
+	m.mu.Lock()
+	m.putAllCalled++
+	m.mu.Unlock()
+}
+
+func (m *mockManager) EvictAll(ctx context.Context, ids []*dto.CacheId) {
+	defer m.evictWG.Done()
+	time.Sleep(m.wait)
+	m.mu.Lock()
+	m.evictAllCalled++
+	m.mu.Unlock()
+}
+
+func TestAsyncAdapter_GetWrapsManager(t *testing.T) {
+	mgr := &mockManager{}
+	f := NewAsyncAdapter(mgr)
+	id := &dto.CacheId{CacheName: "c", Key: "k"}
+	res := f.Get(context.Background(), id)
+	assert.NotNil(t, res)
+	assert.Equal(t, 1, mgr.getAllCalled)
+	assert.Equal(t, id, res.CacheEntry.CacheId)
+}
+
+func TestAsyncAdapter_PutAllAsync(t *testing.T) {
+	mgr := &mockManager{wait: 50 * time.Millisecond}
+	mgr.putWG.Add(1)
+	f := NewAsyncAdapter(mgr)
+	entry := &dto.CacheEntry{CacheId: &dto.CacheId{CacheName: "c", Key: "k"}}
+
+	start := time.Now()
+	f.PutAll(context.Background(), []*dto.CacheEntry{entry})
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 30*time.Millisecond)
+
+	mgr.putWG.Wait()
+	assert.Equal(t, 1, mgr.putAllCalled)
+}
+
+func TestAsyncAdapter_EvictAllAsync(t *testing.T) {
+	mgr := &mockManager{wait: 50 * time.Millisecond}
+	mgr.evictWG.Add(1)
+	f := NewAsyncAdapter(mgr)
+	id := &dto.CacheId{CacheName: "c", Key: "k"}
+
+	start := time.Now()
+	f.EvictAll(context.Background(), []*dto.CacheId{id})
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 30*time.Millisecond)
+
+	mgr.evictWG.Wait()
+	assert.Equal(t, 1, mgr.evictAllCalled)
+}
+
+func TestAsyncAdapter_SingleHelpers(t *testing.T) {
+	mgr := &mockManager{wait: 10 * time.Millisecond}
+	mgr.putWG.Add(1)
+	mgr.evictWG.Add(1)
+	f := NewAsyncAdapter(mgr)
+
+	id := &dto.CacheId{CacheName: "c", Key: "k"}
+	entry := &dto.CacheEntry{CacheId: id}
+
+	f.Put(context.Background(), entry)
+	f.Evict(context.Background(), id)
+	res := f.Get(context.Background(), id)
+
+	mgr.putWG.Wait()
+	mgr.evictWG.Wait()
+
+	assert.Equal(t, 1, mgr.putAllCalled)
+	assert.Equal(t, 1, mgr.evictAllCalled)
+	assert.Equal(t, 1, mgr.getAllCalled)
+	assert.NotNil(t, res)
+}


### PR DESCRIPTION
## Summary
- rename Facade implementation to AsyncManagerAdapter
- update tests to match new naming

## Testing
- `go test ./...` *(fails: go toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68480ca56d38832cbcc5d55403d5a099