### PR TITLE
Migrate logging to zap

### DIFF
--- a/app/api/dto/mapper.go
+++ b/app/api/dto/mapper.go
@@ -2,7 +2,7 @@ package dto
 
 import (
 	"aur-cache-service/internal/cache/config"
-	"log"
+	"go.uber.org/zap"
 )
 
 type ResolverMapper struct {
@@ -20,7 +20,7 @@ func (s *ResolverMapper) MapAllResolvedCacheEntry(cacheEntries []*CacheEntry) []
 	for _, cacheEntry := range cacheEntries {
 		resolved, err := s.mapResolvedCacheEntry(cacheEntry)
 		if err != nil {
-			log.Printf("ERROR: while resolve cacheEntry: %+v, %v", cacheEntry, err)
+			zap.S().Errorw("while resolve cacheEntry", "cacheEntry", cacheEntry, "error", err)
 		} else {
 			resolvedList = append(resolvedList, resolved)
 		}
@@ -44,7 +44,7 @@ func (s *ResolverMapper) MapAllResolvedCacheId(cacheIds []*CacheId) []*ResolvedC
 	for _, cacheId := range cacheIds {
 		resolved, err := s.mapResolvedCacheId(cacheId)
 		if err != nil {
-			log.Printf("ERROR: while resolve cacheId: %+v, %v", cacheId, err)
+			zap.S().Errorw("while resolve cacheId", "cacheId", cacheId, "error", err)
 		} else {
 			resolvedList = append(resolvedList, resolved)
 		}

--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -5,9 +5,11 @@ import (
 	"aur-cache-service/internal/cache"
 	"aur-cache-service/internal/httpserver"
 	"aur-cache-service/internal/integration"
+	"aur-cache-service/internal/logger"
 	"aur-cache-service/internal/manager"
 	"aur-cache-service/internal/metrics"
 	"fmt"
+	"go.uber.org/zap"
 	"log"
 	"net/http"
 	"time"
@@ -21,6 +23,11 @@ const (
 )
 
 func main() {
+
+	if _, err := logger.Init(); err != nil {
+		log.Fatalf("logger init failed: %v", err)
+	}
+	defer logger.Sync()
 
 	metrics.Register()
 
@@ -41,8 +48,8 @@ func main() {
 		Handler: router,
 	}
 
-	log.Printf("starting server on %s", srv.Addr)
+	zap.S().Infow("starting server", "addr", srv.Addr)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("server error: %v", err)
+		zap.S().Fatalw("server error", "error", err)
 	}
 }

--- a/app/go.mod
+++ b/app/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )
 

--- a/app/go.sum
+++ b/app/go.sum
@@ -55,6 +55,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=

--- a/app/internal/cache/controller.go
+++ b/app/internal/cache/controller.go
@@ -5,7 +5,8 @@ import (
 	"aur-cache-service/internal/cache/providers"
 	"aur-cache-service/internal/metrics"
 	"context"
-	"log"
+
+	"go.uber.org/zap"
 )
 
 // Controller определяет высокоуровневый интерфейс для работы с многослойным кэшем.
@@ -71,7 +72,7 @@ func (c *ControllerImpl) GetAll(ctx context.Context, reqs []*dto.ResolvedCacheId
 	for i, service := range c.services {
 		r, err := service.GetAll(ctx, reqs)
 		if err != nil {
-			log.Printf("Layer %d unavailable: %v", i, err)
+			zap.S().Warnw("layer unavailable", "layer", i, "error", err)
 			results[i] = &dto.GetResult{
 				Hits:    []*dto.ResolvedCacheHit{},
 				Misses:  []*dto.ResolvedCacheId{},
@@ -98,7 +99,7 @@ func (c *ControllerImpl) PutAll(ctx context.Context, entries []*dto.ResolvedCach
 		}
 		err := service.PutAll(ctx, entries)
 		if err != nil {
-			log.Printf("Layer %d unavailable: %v", i, err)
+			zap.S().Warnw("layer unavailable", "layer", i, "error", err)
 		}
 	}
 }
@@ -113,7 +114,7 @@ func (c *ControllerImpl) DeleteAll(ctx context.Context, reqs []*dto.ResolvedCach
 	for i, service := range c.services {
 		err := service.DeleteAll(ctx, reqs)
 		if err != nil {
-			log.Printf("Layer %d unavailable: %v", i, err)
+			zap.S().Warnw("layer unavailable", "layer", i, "error", err)
 		}
 	}
 }

--- a/app/internal/cache/factory.go
+++ b/app/internal/cache/factory.go
@@ -3,13 +3,14 @@ package cache
 import (
 	"aur-cache-service/internal/cache/config"
 	"aur-cache-service/internal/cache/providers"
-	"log"
+
+	"go.uber.org/zap"
 )
 
 func CreateCacheService(configFilePath string) config.CacheService {
 	appConfig, err := config.LoadAppConfig(configFilePath)
 	if err != nil {
-		log.Printf("Error reading config file: %v", err)
+		zap.S().Errorw("error reading config file", "error", err)
 	}
 	return config.NewCacheService(appConfig)
 }
@@ -18,14 +19,14 @@ func CreateLayersCacheController(configFilePath string, configCacheService confi
 
 	appConfig, err := config.LoadAppConfig(configFilePath)
 	if err != nil {
-		log.Printf("Error reading config file: %v", err)
+		zap.S().Errorw("error reading config file", "error", err)
 	}
 
 	providerService := config.NewLayerProviderService(appConfig)
 
 	clientServices, err := providers.CreateNewServiceList(providerService.LayerProviders, configCacheService)
 	if err != nil {
-		log.Printf("Error creating service list: %v", err)
+		zap.S().Errorw("error creating service list", "error", err)
 	}
 
 	return CreateControllerImpl(clientServices)

--- a/app/internal/cache/providers/rocks_db.go
+++ b/app/internal/cache/providers/rocks_db.go
@@ -27,10 +27,11 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"strconv"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/linxGnu/grocksdb"
 )
@@ -300,11 +301,11 @@ func (c *RocksDbCF) BatchDelete(ctx context.Context, keys []string) (err error) 
 // StartTTLCollector launches a goroutine that every `interval` scans the ttl_cf
 // and hard‑deletes expired keys. Cancel the ctx to stop the cleaner.
 func (c *RocksDbCF) StartTTLCollector(ctx context.Context, interval time.Duration) {
-	log.Printf("rocksdb TTL collector started with interval %s", interval)
+	zap.S().Infow("rocksdb TTL collector started", "interval", interval)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		defer log.Printf("rocksdb TTL collector stopped")
+		defer zap.S().Info("rocksdb TTL collector stopped")
 		for {
 			select {
 			case <-ctx.Done():

--- a/app/internal/cache/providers/service.go
+++ b/app/internal/cache/providers/service.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // Service обеспечивает доступ к конкретному уровню кэширования.
@@ -83,7 +84,7 @@ func createService(providerConfig *config.LayerProvider, cacheServiceConfig conf
 }
 
 func initProvider(p interface{}) (CacheProvider, error) {
-	log.Printf("init provider: type %T", p)
+	zap.S().Infow("init provider", "type", fmt.Sprintf("%T", p))
 	switch c := p.(type) {
 	case *config.Ristretto:
 		return NewRistretto(*c)
@@ -150,12 +151,12 @@ func (s *ServiceImpl) PutAll(ctx context.Context, reqs []*dto.ResolvedCacheEntry
 	for _, req := range reqs {
 		enabled, err := s.isEnabled(req)
 		if err != nil {
-			log.Printf("cannot check if level is enabled for key %q: %v", req.GetStorageKey(), err)
+			zap.S().Warnw("cannot check level enabled", "key", req.GetStorageKey(), "error", err)
 			continue
 		}
 		ttl, err := s.getTtl(req)
 		if err != nil {
-			log.Printf("cannot get ttl for key %q: %v", req.GetStorageKey(), err)
+			zap.S().Warnw("cannot get ttl", "key", req.GetStorageKey(), "error", err)
 			continue
 		}
 		if !enabled {
@@ -197,7 +198,7 @@ func (s *ServiceImpl) categorizeRequests(reqs []*dto.ResolvedCacheId) (keyToRequ
 
 		enabled, err := s.isEnabled(req)
 		if err != nil {
-			log.Printf("cannot check if level is enabled for key %q: %v", req.GetStorageKey(), err)
+			zap.S().Warnw("cannot check level enabled", "key", req.GetStorageKey(), "error", err)
 			continue
 		}
 

--- a/app/internal/httpserver/router.go
+++ b/app/internal/httpserver/router.go
@@ -6,11 +6,12 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+
+	"go.uber.org/zap"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -98,7 +99,7 @@ func handleSingle(w http.ResponseWriter, r *http.Request, adapter manager.Manage
 		}
 		w.Header().Set("Content-Type", contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(hit); err != nil {
-			log.Printf("encode error: %v", err)
+			zap.S().Errorw("encode error", "error", err)
 		}
 
 	case http.MethodPut:
@@ -183,7 +184,7 @@ func handleBatchGet(w http.ResponseWriter, r *http.Request, adapter manager.Mana
 
 	w.Header().Set("Content-Type", contentTypeJSON)
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{"results": results}); err != nil {
-		log.Printf("encode error: %v", err)
+		zap.S().Errorw("encode error", "error", err)
 	}
 }
 
@@ -306,7 +307,7 @@ func compressGzip(threshold int) func(http.Handler) http.Handler {
 			w.WriteHeader(brw.code)
 			gz := gzip.NewWriter(w)
 			if _, err := gz.Write([]byte(data)); err != nil {
-				log.Printf("gzip write error: %v", err)
+				zap.S().Errorw("gzip write error", "error", err)
 			}
 			gz.Close()
 		})

--- a/app/internal/logger/logger.go
+++ b/app/internal/logger/logger.go
@@ -1,0 +1,20 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+)
+
+// Init initializes a global zap logger and returns it.
+func Init() (*zap.Logger, error) {
+	l, err := zap.NewDevelopment()
+	if err != nil {
+		return nil, err
+	}
+	zap.ReplaceGlobals(l)
+	return l, nil
+}
+
+// Sync flushes any buffered log entries.
+func Sync() {
+	_ = zap.L().Sync()
+}


### PR DESCRIPTION
## Summary
- switch logging to zap with global init
- replace log.Printf and log.Fatalf with zap
- update providers and managers to use zap
- add internal logger package

## Testing
- `go test ./...` *(fails: missing rocksdb headers)*

------
https://chatgpt.com/codex/tasks/task_e_684fe52f88b0832c8dd1012339a43e5a