### PR TITLE
Enable Telegram error alerts

### DIFF
--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -13,6 +13,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"telegram-alerts-go/alert"
 )
 
 const (
@@ -50,6 +52,6 @@ func main() {
 
 	zap.S().Infow("starting server", "addr", srv.Addr)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		zap.S().Fatalw("server error", "error", err)
+		zap.S().Fatalw(alert.Prefix("server error"), "error", err)
 	}
 }

--- a/app/go.mod
+++ b/app/go.mod
@@ -9,18 +9,18 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redis/go-redis/v9 v9.8.0
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
+	telegram-alerts-go v0.0.0-20250616092414-fb9fa9ae520e
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )
 
@@ -35,3 +35,5 @@ require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 )
+
+replace telegram-alerts-go => github.com/NikolayNN/telegram-alerts-go v0.0.0-20250616092414-fb9fa9ae520e

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,3 +1,5 @@
+github.com/NikolayNN/telegram-alerts-go v0.0.0-20250616092414-fb9fa9ae520e h1:dyTjeUj0aDACPGTvFAp2lmY2S90GKVH8rVH12Q9V/3w=
+github.com/NikolayNN/telegram-alerts-go v0.0.0-20250616092414-fb9fa9ae520e/go.mod h1:D6FEXlAVvJfX+nyHTriAvo7ErUJIywl3aoHNS2vqYXw=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -8,7 +10,6 @@ github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/ristretto v0.2.0 h1:XAfl+7cmoUDWW/2Lx8TGZQjjxIQ2Ley9DSf52dru4WE=
@@ -55,6 +56,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/app/internal/cache/factory.go
+++ b/app/internal/cache/factory.go
@@ -5,12 +5,13 @@ import (
 	"aur-cache-service/internal/cache/providers"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 )
 
 func CreateCacheService(configFilePath string) config.CacheService {
 	appConfig, err := config.LoadAppConfig(configFilePath)
 	if err != nil {
-		zap.S().Errorw("error reading config file", "error", err)
+		zap.S().Errorw(alert.Prefix("error reading config file"), "error", err)
 	}
 	return config.NewCacheService(appConfig)
 }
@@ -19,14 +20,14 @@ func CreateLayersCacheController(configFilePath string, configCacheService confi
 
 	appConfig, err := config.LoadAppConfig(configFilePath)
 	if err != nil {
-		zap.S().Errorw("error reading config file", "error", err)
+		zap.S().Errorw(alert.Prefix("error reading config file"), "error", err)
 	}
 
 	providerService := config.NewLayerProviderService(appConfig)
 
 	clientServices, err := providers.CreateNewServiceList(providerService.LayerProviders, configCacheService)
 	if err != nil {
-		zap.S().Errorw("error creating service list", "error", err)
+		zap.S().Errorw(alert.Prefix("error creating service list"), "error", err)
 	}
 
 	return CreateControllerImpl(clientServices)

--- a/app/internal/cache/providers/redis.go
+++ b/app/internal/cache/providers/redis.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 )
 
 type Redis struct {
@@ -103,7 +104,7 @@ func (c *Redis) BatchPut(ctx context.Context, items map[string]string, ttls map[
 
 		_, err = pipe.Exec(ctx)
 		if err != nil {
-			zap.S().Errorw("redis pipeline exec error", "chunk", chunkIndex, "error", err)
+			zap.S().Errorw(alert.Prefix("redis pipeline exec error"), "chunk", chunkIndex, "error", err)
 			return fmt.Errorf("ошибка пакетного сохранения в Redis (chunk %d): %w", chunkIndex, err)
 		}
 	}
@@ -128,7 +129,7 @@ func (c *Redis) BatchDelete(ctx context.Context, keys []string) (err error) {
 	for chunkIndex, chunk := range chunks {
 		_, err = c.rdb.Unlink(ctx, chunk...).Result()
 		if err != nil {
-			zap.S().Errorw("redis unlink error", "chunk", chunkIndex+1, "total", len(chunks), "error", err)
+			zap.S().Errorw(alert.Prefix("redis unlink error"), "chunk", chunkIndex+1, "total", len(chunks), "error", err)
 			return fmt.Errorf("ошибка пакетного удаления из Redis (chunk %d/%d, keys: %d): %w",
 				chunkIndex+1, len(chunks), len(chunk), err)
 		}

--- a/app/internal/httpserver/router.go
+++ b/app/internal/httpserver/router.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -99,7 +100,7 @@ func handleSingle(w http.ResponseWriter, r *http.Request, adapter manager.Manage
 		}
 		w.Header().Set("Content-Type", contentTypeJSON)
 		if err := json.NewEncoder(w).Encode(hit); err != nil {
-			zap.S().Errorw("encode error", "error", err)
+			zap.S().Errorw(alert.Prefix("encode error"), "error", err)
 		}
 
 	case http.MethodPut:
@@ -184,7 +185,7 @@ func handleBatchGet(w http.ResponseWriter, r *http.Request, adapter manager.Mana
 
 	w.Header().Set("Content-Type", contentTypeJSON)
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{"results": results}); err != nil {
-		zap.S().Errorw("encode error", "error", err)
+		zap.S().Errorw(alert.Prefix("encode error"), "error", err)
 	}
 }
 
@@ -307,7 +308,7 @@ func compressGzip(threshold int) func(http.Handler) http.Handler {
 			w.WriteHeader(brw.code)
 			gz := gzip.NewWriter(w)
 			if _, err := gz.Write([]byte(data)); err != nil {
-				zap.S().Errorw("gzip write error", "error", err)
+				zap.S().Errorw(alert.Prefix("gzip write error"), "error", err)
 			}
 			gz.Close()
 		})

--- a/app/internal/integration/service.go
+++ b/app/internal/integration/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 )
 
 // Service представляет интерфейс получения значений из внешнего API по списку идентификаторов кеша.
@@ -82,7 +83,7 @@ func (s *ServiceImpl) GetAll(ctx context.Context, reqs []*dto.ResolvedCacheId) *
 func (s *ServiceImpl) handleGroup(ctx context.Context, cacheName string, group []*dto.ResolvedCacheId) *dto.GetResult {
 	cache, err := s.configService.GetCacheByName(cacheName)
 	if err != nil {
-		zap.S().Errorw("unknown cache", "cache", cacheName, "error", err)
+		zap.S().Errorw(alert.Prefix("unknown cache"), "cache", cacheName, "error", err)
 		return &dto.GetResult{
 			Hits:    []*dto.ResolvedCacheHit{},
 			Misses:  []*dto.ResolvedCacheId{},
@@ -99,7 +100,7 @@ func (s *ServiceImpl) handleGroup(ctx context.Context, cacheName string, group [
 	respMap, err := s.fetcher.GetAll(ctx, keys, &cfg)
 	metrics.RecordExternalRequest(cacheName, err, time.Since(start).Seconds())
 	if err != nil {
-		zap.S().Errorw("fetch error", "cache", cacheName, "error", err)
+		zap.S().Errorw(alert.Prefix("fetch error"), "cache", cacheName, "error", err)
 		return &dto.GetResult{Skipped: group}
 	}
 

--- a/app/internal/logger/logger.go
+++ b/app/internal/logger/logger.go
@@ -2,6 +2,10 @@ package logger
 
 import (
 	"go.uber.org/zap"
+
+	"telegram-alerts-go/config"
+	"telegram-alerts-go/loghook"
+	"telegram-alerts-go/telegram"
 )
 
 // Init initializes a global zap logger and returns it.
@@ -9,6 +13,12 @@ func Init() (*zap.Logger, error) {
 	l, err := zap.NewDevelopment()
 	if err != nil {
 		return nil, err
+	}
+
+	cfg := config.LoadFromEnv()
+	if cfg.BotToken != "" && cfg.ChannelID != "" {
+		client := telegram.NewClient(cfg.BotToken, cfg.ChannelID)
+		l = l.WithOptions(loghook.NewTelegramHook(client, cfg.ServiceName))
 	}
 	zap.ReplaceGlobals(l)
 	return l, nil

--- a/app/internal/manager/async_adapter.go
+++ b/app/internal/manager/async_adapter.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 )
 
 // Максимум 64 одновременных async-операций (PutAll/EvictAll).
@@ -92,7 +93,7 @@ func (a *AsyncManagerAdapter) runAsync(name string, f func(ctx context.Context),
 
 		defer func() {
 			if r := recover(); r != nil {
-				zap.S().Errorf("async panic: %v", r)
+				zap.S().Errorf(alert.Prefix("async panic: %v"), r)
 			}
 		}()
 

--- a/app/internal/manager/cache_manager.go
+++ b/app/internal/manager/cache_manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"telegram-alerts-go/alert"
 )
 
 // Manager определяет высокоуровневый интерфейс управления данными в многослойном кэше.
@@ -75,7 +76,7 @@ func (m *ManagerImpl) fillMissingLevels(ctx context.Context, finalHits []*dto.Re
 
 	defer func() {
 		if r := recover(); r != nil {
-			zap.S().Errorf("panic in goroutine fillMissingLevels: %v", r)
+			zap.S().Errorf(alert.Prefix("panic in goroutine fillMissingLevels: %v"), r)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- add telegram-alerts-go dependency via replace in `go.mod`
- hook zap logger to forward errors to Telegram
- prefix error logs with alert helper so they are forwarded
- update server to send fatal errors via Telegram

## Testing
- `go test ./...` *(fails: missing RocksDB headers)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4e086cc832c956b815c57b20247