### PR TITLE
Remove single cache endpoints

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -50,29 +50,13 @@ Multi-Level Cache Service - это экспериментальное прило
 ## REST API
 Ниже приведены основные эндпоинты сервиса.
 
-### Получение значения
-```
-GET /api/cache/{cacheName}/{key}
-```
-Возвращает значение из кэша или `404`, если оно отсутствует.
 
-### Сохранение значения
-```
-PUT /api/cache/{cacheName}/{key}
-```
-В теле запроса передаётся JSON со значением. Данные записываются во все уровни кэша.
-
-### Удаление значения
-```
-DELETE /api/cache/{cacheName}/{key}
-```
-Удаляет данные из всех уровней.
 
 ### Пакетные запросы
 ```
-POST /api/cache/batch/get
-POST /api/cache/batch/put
-POST /api/cache/batch/delete
+POST /api/v1/cache/get_all
+POST /api/v1/cache/put_all
+POST /api/v1/cache/evict_all
 ```
 Формат тела запроса содержит массив объектов с полями `c` (cacheName) и `k` (key). Для PUT также передаётся `v` (value).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,15 +13,6 @@ go build ./cmd/cli
 Примеры использования:
 
 ```bash
-# сохранить значение
-./cli -cache user put -key 42 -value '{"name":"Bob"}'
-
-# получить значение
-./cli -cache user get -key 42
-
-# удалить значение
-./cli -cache user evict -key 42
-
 # получить несколько значений
 ./cli -cache user get-all -key 1 -key 2
 


### PR DESCRIPTION
## Summary
- drop single GET/PUT/DELETE handlers from router
- remove related CLI commands and docs
- update README to only mention batch endpoints
- clean up tests
- rename batch endpoints to `/api/v1/cache/*_all`

## Testing
- `go test ./...` *(fails: `rocksdb/c.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850219b3a28832c8d836bc96b72be12