### PR TITLE
Add health endpoint for metrics server

### DIFF
--- a/app/internal/httpserver/router.go
+++ b/app/internal/httpserver/router.go
@@ -30,13 +30,20 @@ const (
 	headerVary            = "Vary"                     // HTTP заголовок для указания зависимости от других заголовков
 	encodingGzip          = "gzip"                     // Название gzip кодировки
 	metricsPath           = "/metrics"                 // Путь для метрик Prometheus
+	metricsHealthPath     = "/metrics/health"          // Путь для проверки состояния
 )
 
 func NewMetricRouter() http.Handler {
 	metric_router := chi.NewRouter()
 
 	// /metrics хендлер без middleware
-	metric_router.Method(http.MethodGet, "/metrics", promhttp.Handler())
+	metric_router.Method(http.MethodGet, metricsPath, promhttp.Handler())
+
+	// /metrics/health хендлер без middleware
+	metric_router.Method(http.MethodGet, metricsHealthPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", contentTypeJSON)
+		io.WriteString(w, `{"status":"UP"}`)
+	}))
 	return metric_router
 }
 

--- a/app/internal/httpserver/router_test.go
+++ b/app/internal/httpserver/router_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -150,5 +151,18 @@ func TestMetricsNoGzip(t *testing.T) {
 	router.ServeHTTP(rr, req)
 	if rr.Header().Get(headerContentEncoding) == encodingGzip {
 		t.Fatalf("/metrics response should not be gzipped")
+	}
+}
+
+func TestMetricsHealth(t *testing.T) {
+	router := NewMetricRouter()
+	req := httptest.NewRequest(http.MethodGet, metricsHealthPath, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d", rr.Code)
+	}
+	if body := strings.TrimSpace(rr.Body.String()); body != `{"status":"UP"}` {
+		t.Fatalf("unexpected body: %s", body)
 	}
 }


### PR DESCRIPTION
## Summary
- add `/metrics/health` endpoint
- test the new health check

## Testing
- `go test ./...` *(fails: LayerProviderService field mismatch and RocksDB C library issues)*
- `go test ./...` in `cli` (passes: no tests)

------
https://chatgpt.com/codex/tasks/task_e_6877a902ddd4832c8acf7d9115a32b5b